### PR TITLE
Rewrite parse_procfs_maps() to return a linked list of maps_entry_t structures

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -5,6 +5,11 @@
 #include <limits.h>
 #include <sys/types.h>
 
+/*
+ *   Defines the buffer size for reading lines from the /proc/PID/maps file.
+ *   The last field in each line may contain an absolute file path, thus PATH_MAX, 
+ *   and 256 is an arbitrary value chosen to account all other fields.
+ */
 #define LINE_SIZE PATH_MAX + 256 
 
 typedef struct _maps_entry_t {
@@ -16,8 +21,23 @@ typedef struct _maps_entry_t {
     int dev_minor;
     uint64_t inode;
     char pathname[PATH_MAX];
+    struct _maps_entry_t* next;
 } maps_entry_t;
 
-int parse_procfs(const pid_t);
+/*
+ *   Parses the /proc/PID/maps file and returns a pointer to a linked list
+ *   of maps_entry_t structures. Each node in the linked list represents 
+ *   an entry from the maps file, with fields populated accordingly.
+ *
+ *   The caller is responsible for freeing allocated memory for the linked list.
+ *
+ *   Returns:
+ *       A pointer to the head of the linked list containing parsed entries, 
+ *       or NULL if an error occurs during parsing.
+ */
+maps_entry_t* parse_procfs_maps(const pid_t);
+
+void free_maps_list(maps_entry_t*);
+void print_maps_list(maps_entry_t*);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -65,12 +65,14 @@ int main(int argc, char** argv) {
 
     printf("[DEBUG] Proccess %d has been stopped\n", pid);
 
-    ret = parse_procfs(pid);
-    if (ret < 0) {
+    maps_entry_t* pid_maps = parse_procfs_maps(pid);
+    if (!pid_maps) {
         fprintf(stderr,
                 "Error occured while parsing /proc/%d/maps\n", 
                 pid);
-        exit(EXIT_FAILURE);
+    } else {
+        print_maps_list(pid_maps);
+        free_maps_list(pid_maps);
     }
 
     ret = kill(pid, SIGCONT);

--- a/src/parser.c
+++ b/src/parser.c
@@ -3,57 +3,98 @@
 #include <stdlib.h>
 #include <string.h>
 
-int parse_procfs(const pid_t pid) {
+maps_entry_t* parse_procfs_maps(const pid_t pid) {
+    maps_entry_t* pid_maps = NULL;
+    maps_entry_t* tail = pid_maps;
+
     char maps_path[PATH_MAX];
     snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid);
 
     FILE *maps_file = fopen(maps_path, "r");
     if (!maps_file) {
-        return -1; 
+        return NULL; 
     }
 
     char line[LINE_SIZE];
     char format[64];
+
+    /*  Each line is formatted as follows:
+     * ffffbddf0000-ffffbdf78000 r-xp 00000000 fd:00 1836518                    /usr/lib/aarch64-linux-gnu/libc.so.6 
+     */ 
     snprintf(format, sizeof(format), "%%llx-%%llx %%4s %%llx %%x:%%x %%lu %%%d[^\n]", PATH_MAX - 1);
 
     while (fgets(line, sizeof(line), maps_file)) {
-        maps_entry_t maps_entry;
-        maps_entry.pathname[0] = '\0';
+        maps_entry_t* maps_entry = malloc(sizeof(maps_entry_t));
+        if (!maps_entry) {
+            fprintf(stderr,
+                    "Not enough memory, aborting\n");
+            free_maps_list(pid_maps);
+            fclose(maps_file);
+            return NULL;
+        }
 
+        maps_entry->pathname[0] = '\0';
         int matched = sscanf(line, 
                              format,
-                             &maps_entry.start_addr,
-                             &maps_entry.end_addr,
-                             maps_entry.perms,
-                             &maps_entry.offset,
-                             &maps_entry.dev_major,
-                             &maps_entry.dev_minor,
-                             &maps_entry.inode,
-                             maps_entry.pathname);
+                             &maps_entry->start_addr,
+                             &maps_entry->end_addr,
+                             maps_entry->perms,
+                             &maps_entry->offset,
+                             &maps_entry->dev_major,
+                             &maps_entry->dev_minor,
+                             &maps_entry->inode,
+                             maps_entry->pathname);
 
         if (matched < 7) {
             fprintf(stderr,
                     "Error occured while parsing line: %s", 
                     line);
-            return -1; 
+            free_maps_list(pid_maps);
+            fclose(maps_file);
+            return NULL; 
         }
 
-        if (maps_entry.pathname[0] == '\0') {
-            strncpy(maps_entry.pathname, "[anonymous]", PATH_MAX);
+        if (maps_entry->pathname[0] == '\0') {
+            strncpy(maps_entry->pathname, "[anonymous]", PATH_MAX);
         }
 
-        printf("[DEBUG] Parsed entry\n%s", line);
-        printf("Start addr: %lx\n", maps_entry.start_addr);
-        printf("End addr: %lx\n", maps_entry.end_addr);
-        printf("Permissions: %s\n", maps_entry.perms);
-        printf("Offset: %lx\n", maps_entry.offset);
-        printf("Dev major: %x\n", maps_entry.dev_major);
-        printf("Dev minor: %x\n", maps_entry.dev_minor);
-        printf("Inode: %lu\n", maps_entry.inode);
-        printf("Pathname: %s\n", maps_entry.pathname);
+        if (pid_maps) {
+            tail->next = maps_entry;
+            tail = maps_entry;
+        } else {
+            pid_maps = tail = maps_entry;
+        }
+
+        tail->next = NULL;
     }
 
     fclose(maps_file);
 
-    return EXIT_SUCCESS;
+    return pid_maps;
 }
+
+void free_maps_list(maps_entry_t* head) {
+    while (head) {
+        maps_entry_t* next = head->next;
+        free(head);
+        head = next;
+    }
+}
+
+void print_maps_list(maps_entry_t* head) {
+    maps_entry_t* curr = head;
+    while (curr) {
+        printf("Start addr: %lx\n", curr->start_addr);
+        printf("End addr: %lx\n", curr->end_addr);
+        printf("Permissions: %s\n", curr->perms);
+        printf("Offset: %lx\n", curr->offset);
+        printf("Dev major: %x\n", curr->dev_major);
+        printf("Dev minor: %x\n", curr->dev_minor);
+        printf("Inode: %lu\n", curr->inode);
+        printf("Pathname: %s\n", curr->pathname);
+
+        curr = curr->next;
+    }
+}
+
+


### PR DESCRIPTION
Function parse_procfs_maps() now returns a pointer to a linked list of maps_entry_t structures and can be used as the first step of the memory dump process.