### PR TITLE
Remove unnecessary memory management from write_program_header_table()

### DIFF
--- a/include/elf_utils.h
+++ b/include/elf_utils.h
@@ -5,6 +5,6 @@
 #include "parser.h"
 
 int write_elf_header(const int, const size_t);
-int write_program_header_table(const int, const maps_entry_t*, const size_t);
+int write_program_header_table(const int, const maps_entry_t*);
 
 #endif

--- a/src/dumper.c
+++ b/src/dumper.c
@@ -13,8 +13,8 @@
 #define DUMP_ERROR -1
 
 int create_coredump(const pid_t pid) {
-    int ret;
     maps_entry_t* pid_maps;
+    int ret;
 
     pid_maps = parse_procfs_maps(pid);
     if (!pid_maps) {
@@ -51,7 +51,7 @@ int create_coredump(const pid_t pid) {
         return -1;
     }
 
-    ret = write_program_header_table(coredump_fd, pid_maps, phdr_count);
+    ret = write_program_header_table(coredump_fd, pid_maps);
     if (ret < 0) {
         fprintf(stderr,
                 "Error occured while writing to file %s\n",
@@ -60,6 +60,8 @@ int create_coredump(const pid_t pid) {
         close(coredump_fd);
         return -1;
     }
+
+    // Write program headers
 
     close(coredump_fd);
 

--- a/src/elf_utils.c
+++ b/src/elf_utils.c
@@ -42,26 +42,16 @@ int write_elf_header(const int fd, const size_t phdr_count) {
     return 0;
 }
 
-int write_program_header_table(const int fd, const maps_entry_t* head, const size_t phdr_count) {
-    size_t table_sz = sizeof(Elf64_Phdr) * phdr_count;
-    Elf64_Phdr* phdr_table = malloc(table_sz);
-    if (!phdr_table) {
-        return -1;
-    }
-
+int write_program_header_table(const int fd, const maps_entry_t* head) {
     const maps_entry_t* entry = head;
-    size_t index = 0;
     while (entry) {
-        phdr_table[index++] = create_program_header(entry);
+        Elf64_Phdr phdr = create_program_header(entry);
+        if (write(fd, &phdr, sizeof(Elf64_Phdr)) != sizeof(Elf64_Phdr)) {
+            return -1;
+        }
+
         entry = entry->next;
     }
-
-    if (write(fd, phdr_table, table_sz) != table_sz) {
-        free(phdr_table);
-        return -1;
-    }
-
-    free(phdr_table);
 
     return 0;
 }


### PR DESCRIPTION
Remove useless malloc() and free() calls.